### PR TITLE
Modify deprecated WebView method

### DIFF
--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -25,7 +25,7 @@ var Canvas = React.createClass({
                     opaque={false}
                     underlayColor={'transparent'}
                     style={this.props.style}
-                    javaScriptEnabledAndroid={true}
+                    javaScriptEnabled={true}
                 />
             </View>
         );


### PR DESCRIPTION
On React Native v0.19.0, usage of this deprecated method would trigger a warning. Please generally replace it, thanks!