### PR TITLE
Fix rounding issue causing border-like artifacts. 

### DIFF
--- a/lib/QRCode.js
+++ b/lib/QRCode.js
@@ -25,8 +25,8 @@ function renderCanvas(canvas) {
     cells.forEach(function(row, rowIndex) {
         row.forEach(function(column, columnIndex) {
             ctx.fillStyle = column ? bgColor : fgColor;
-            var w = Math.ceil((rowIndex + 1) * cellWidth) - Math.floor(rowIndex * cellWidth);
-            var h = Math.ceil((columnIndex + 1) * cellHeight) - Math.floor(columnIndex * cellHeight);
+            var w = Math.round((rowIndex + 1) * cellWidth) - Math.round(rowIndex * cellWidth);
+            var h = Math.round((columnIndex + 1) * cellHeight) - Math.round(columnIndex * cellHeight);
             ctx.fillRect(Math.round(rowIndex * cellWidth), Math.round(columnIndex * cellHeight), w, h);
         });
     });


### PR DESCRIPTION
Due to the usage of `floor` and `ceil`, some rows and columns of the canvas does not have rects filled in. This seems to be fine with normal colors, but when using opacity (e.g. `rgba(255, 255, 255, 0.9)`), there border-like artifacts from the rounding. 

<img width="320" alt="screen shot 2016-03-10 at 3 59 02 pm" src="https://cloud.githubusercontent.com/assets/6350939/13684659/b295fb04-e6da-11e5-94b2-0228b12a2343.png">

Changing to `round` seems to fix this.

<img width="323" alt="screen shot 2016-03-10 at 4 08 11 pm" src="https://cloud.githubusercontent.com/assets/6350939/13684672/c3b0d774-e6da-11e5-8ae4-b0cc418f1b28.png">
