### PR TITLE
Disable scrolling on WebView.

### DIFF
--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -26,6 +26,7 @@ var Canvas = React.createClass({
                     underlayColor={'transparent'}
                     style={this.props.style}
                     javaScriptEnabled={true}
+                    scrollEnabled={false}
                 />
             </View>
         );


### PR DESCRIPTION
The WebView is able to scroll, so if a user were to drag the QR code down, it would clip.

<img width="329" alt="screen shot 2016-03-29 at 12 04 45 pm" src="https://cloud.githubusercontent.com/assets/6350939/14114827/acf34bb8-f5a6-11e5-9823-5132ad08d6a5.png">
<img width="316" alt="screen shot 2016-03-29 at 12 05 02 pm copy" src="https://cloud.githubusercontent.com/assets/6350939/14114831/af0d8a58-f5a6-11e5-886f-8626e0e85cf2.png">

Only added line to disable scrolling in the WebView.