### PR TITLE
Migrating from React.createClass

### DIFF
--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -1,16 +1,19 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
+
 var {
     View,
     WebView
 } = require('react-native');
 
-var Canvas = React.createClass({
+var Canvas = createReactClass({
     propTypes: {
-        style: React.PropTypes.object,
-        context: React.PropTypes.object,
-        render: React.PropTypes.func.isRequired
+        style: PropTypes.object,
+        context: PropTypes.object,
+        render: PropTypes.func.isRequired
     },
 
     render() {

--- a/lib/QRCode.js
+++ b/lib/QRCode.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var Canvas = require('./Canvas.js');
 var qr = require('qr.js');
 var {
@@ -45,12 +47,12 @@ function renderCanvas(canvas) {
     });
 }
 
-var QRCode = React.createClass({
+var QRCode = createReactClass({
     PropTypes: {
-        value: React.PropTypes.string,
-        size: React.PropTypes.number,
-        bgColor: React.PropTypes.string,
-        fgColor: React.PropTypes.string,
+        value: PropTypes.string,
+        size: PropTypes.number,
+        bgColor: PropTypes.string,
+        fgColor: PropTypes.string,
     },
 
     getDefaultProps: function() {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "homepage": "https://github.com/cssivision/react-native-qrcode#readme",
   "dependencies": {
+    "create-react-class": "^15.6.0",
+    "prop-types": "^15.5.10",
     "qr.js": "0.0.0"
   }
 }


### PR DESCRIPTION
PR for migration from React.createClass, which is no longer supported for React > 15.5. More info is here - https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.createclass


This PR works for me with:
 - react@16.0.0-alpha.12
 - react-native@0.46.4 