### PR TITLE
Adapt to RN 0.48.0-rc.0.

### DIFF
--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -23,6 +23,7 @@ var Canvas = createReactClass({
             <View style={this.props.style}>
                 <WebView
                     automaticallyAdjustContentInsets={false}
+                    scalesPageToFit={false}
                     contentInset={{top: 0, right: 0, bottom: 0, left: 0}}
                     source={{html: "<style>*{margin:0;padding:0;}canvas{transform:translateZ(0);}</style><canvas></canvas><script>var canvas = document.querySelector('canvas');(" + renderString + ").call(" + contextString + ", canvas);</script>"}}
                     opaque={false}


### PR DESCRIPTION
Change of WebView on RN 0.48.0-rc.0 causes that scales the QR code incorrectly on iOS.

https://github.com/facebook/react-native/commit/185948604c1bd58abe8db3632a78d768268b1cc4

Scaled incorrectly:
![](https://user-images.githubusercontent.com/143255/29115096-4c0249d0-7d31-11e7-9340-608de84d8eac.png)

Fixed:
![](https://user-images.githubusercontent.com/143255/29115137-6eb6b498-7d31-11e7-8169-725ea876070f.png)

Example code:
```
import React, { Component } from 'react';
import {
  AppRegistry,
  StyleSheet,
  Text,
  View
} from 'react-native';
import QRCode from 'react-native-qrcode'

export default class RNQRcodeExample extends Component {
  render() {
    return (
      <View style={styles.container}>
        <QRCode
          value={'test'}
          size={200}
          bgColor={'black'}
          fgColor={'white'}
        />
      </View>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },
});

AppRegistry.registerComponent('RNQRcodeExample', () => RNQRcodeExample);
```