### PR TITLE
Added fixed padded border around generated QR Code to improve read accuracy

### DIFF
--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -26,7 +26,7 @@ var Canvas = createReactClass({
                     automaticallyAdjustContentInsets={false}
                     scalesPageToFit={Platform.OS === 'android'}
                     contentInset={{top: 0, right: 0, bottom: 0, left: 0}}
-                    source={{html: "<style>*{margin:0;padding:0;}canvas{transform:translateZ(0);}</style><canvas></canvas><script>var canvas = document.querySelector('canvas');(" + renderString + ").call(" + contextString + ", canvas);</script>"}}
+                    source={{html: "<style>*{margin:0;padding: 5;}canvas{transform:translateZ(0);}</style><canvas></canvas><script>var canvas = document.querySelector('canvas');(" + renderString + ").call(" + contextString + ", canvas);</script>"}}
                     opaque={false}
                     underlayColor={'transparent'}
                     style={this.props.style}

--- a/lib/QRCode.js
+++ b/lib/QRCode.js
@@ -98,7 +98,7 @@ var QRCode = createReactClass({
                         cells: qr(value).modules,
                     }}
                     render={renderCanvas}
-                    style={{height: size, width: size}}
+                    style={{height: size+30, width: size+30}}
                 />
             </View>
         );

--- a/lib/QRCode.js
+++ b/lib/QRCode.js
@@ -98,7 +98,7 @@ var QRCode = createReactClass({
                         cells: qr(value).modules,
                     }}
                     render={renderCanvas}
-                    style={{height: size+30, width: size+30}}
+                    style={{height: size + 30, width: size + 30}}
                 />
             </View>
         );


### PR DESCRIPTION
I noticed that for some QR codes that are in a page with a background color (eg blue), the accuracy of the read is affected if there is no padded border around the QR code.

I just added a small 5px padding around the QR code. Hope you find it useful

thanks and keep up the good work!