### PR TITLE
Make canvas transparent

### DIFF
--- a/lib/QRCode.js
+++ b/lib/QRCode.js
@@ -18,7 +18,6 @@ function renderCanvas(canvas) {
     canvas.height = size;
     canvas.style.left = (window.innerWidth - size) / 2 + 'px';
     if(window.innerHeight > size) canvas.style.top = (window.innerHeight - size) / 2 + 'px';
-    ctx.fillRect(0, 0, size, size);
     var cells = this.cells;
     var cellWidth = this.size / cells.length;
     var cellHeight = this.size / cells.length;
@@ -104,7 +103,7 @@ var QRCode = createReactClass({
                     render={renderCanvas}
                     onLoad={this.props.onLoad}
                     onLoadEnd={this.props.onLoadEnd}
-                    style={{height: size, width: size}}
+                    style={{height: size, width: size, backgroundColor: 'transparent' }}
                 />
             </View>
         );

--- a/lib/QRCode.js
+++ b/lib/QRCode.js
@@ -29,6 +29,7 @@ function renderCanvas(canvas) {
             var nTop = rowIndex * cellHeight;
             ctx.fillStyle = ctx.strokeStyle = column ? bgColor : fgColor;
             ctx.lineWidth = 1;
+            ctx.clearRect(nLeft, nTop, cellWidth, cellHeight);
             ctx.fillRect(nLeft, nTop, cellWidth, cellHeight);
             ctx.strokeRect(
                 Math.floor(nLeft) + 0.5,


### PR DESCRIPTION
**Problem**:
![image](https://user-images.githubusercontent.com/7250604/39565556-9ca6095c-4ee2-11e8-9ac4-69a1e243b12e.png)
Current implementation doesn't allow to create qr-code with transparent backgrounds.

This PR turns transparency by default.
