### PR TITLE
ShashankKumawat-useWebKit-Update

### DIFF
--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -22,13 +22,19 @@ var Canvas = createReactClass({
     render() {
         var contextString = JSON.stringify(this.props.context);
         var renderString = this.props.render.toString();
+        var qrCodeStyle =
+			Platform.OS === 'ios'
+				? '<meta name="viewport" content="width=device-width, initial-scale=1"> <style>*{width:100%;height:100%;resize:contain;margin:0; padding:0;}'
+				: '<style>*{margin:0;padding:0;}';
         return (
             <View style={this.props.style}>
                 <WebView
+                    useWebKit={true}
                     automaticallyAdjustContentInsets={false}
                     scalesPageToFit={Platform.OS === 'android'}
                     contentInset={{top: 0, right: 0, bottom: 0, left: 0}}
-                    source={{html: "<style>*{margin:0;padding:0;}canvas{transform:translateZ(0);}</style><canvas></canvas><script>var canvas = document.querySelector('canvas');(" + renderString + ").call(" + contextString + ", canvas);</script>"}}
+                    source={{html: qrCodeStyle +
+							"canvas{transform:translateZ(0);}</style><canvas></canvas><script>var canvas = document.querySelector('canvas');(" + renderString + ").call(" + contextString + ", canvas);</script>"}}
                     opaque={false}
                     underlayColor={'transparent'}
                     style={this.props.style}


### PR DESCRIPTION
As iOS is warning for UIWebView depreciation  'useWebKit' prop should be true. Style changes should be made for QRCode view as 'scalesPageToFit' doesn't work for iOS after using 'useWebKit' property.



☞ After Using '**useWebKit**' property as **true** change in styling of QRCode occurs and doesn't remain as before so, Style refactoring needed.

![Simulator Screen Shot - iPhone 8 - 2019-10-22 at 18 52 13](https://user-images.githubusercontent.com/42731404/67290001-1fdd2280-f4fd-11e9-86da-acebc6247a80.png)




☞ After Using '**useWebKit**' property as **true** and after adding new style to QRCode.

![Simulator Screen Shot - iPhone 8 - 2019-10-22 at 18 47 46](https://user-images.githubusercontent.com/42731404/67289627-89a8fc80-f4fc-11e9-8efb-93798cab6240.png)
