### PR TITLE
fix: Use react-native-webview instead of reaction-native/webview

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A react-native component to generate [QRcode](http://en.wikipedia.org/wiki/QR_co
 
 ## Installation
 ```sh
-npm install react-native-qrcode --save
+npm install react-native-webview react-native-qrcode --save
 ```
 ## Usage
 ```jsx

--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -6,9 +6,10 @@ var createReactClass = require('create-react-class');
 
 var {
     View,
-    WebView,
     Platform
 } = require('react-native');
+
+var { WebView } = require('react-native-webview')
 
 var Canvas = createReactClass({
     propTypes: {

--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -9,7 +9,17 @@ var {
     Platform
 } = require('react-native');
 
-var { WebView } = require('react-native-webview')
+var {WebView} = require('react-native-webview');
+
+// Fixed QRCode not filling the whole screen
+var AutoSetScale = `
+  setTimeout(() => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0');
+    meta.setAttribute('name', 'viewport');
+    document.getElementsByTagName('head')[0].appendChild(meta);
+  }, 100)
+`
 
 var Canvas = createReactClass({
     propTypes: {
@@ -26,6 +36,7 @@ var Canvas = createReactClass({
         return (
             <View style={this.props.style}>
                 <WebView
+                    injectedJavaScript={AutoSetScale}
                     automaticallyAdjustContentInsets={false}
                     scalesPageToFit={Platform.OS === 'android'}
                     contentInset={{top: 0, right: 0, bottom: 0, left: 0}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-qrcode",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "react-native qrocode generator",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "create-react-class": "^15.6.0",
     "prop-types": "^15.5.10",
-    "qr.js": "0.0.0"
+    "qr.js": "0.0.0",
+    "react-native-webview": "^8.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-qrcode",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "react-native qrocode generator",
   "main": "index.js",
   "repository": {
@@ -20,7 +20,9 @@
   "dependencies": {
     "create-react-class": "^15.6.0",
     "prop-types": "^15.5.10",
-    "qr.js": "0.0.0",
-    "react-native-webview": "^8.0.3"
+    "qr.js": "0.0.0"
+  },
+  "peerDependencies": {
+    "react-native-webview": "*"
   }
 }


### PR DESCRIPTION
Warning Please use the react-native-community/react-native-webview fork of this component instead. To reduce the surface area of React Native, <WebView/> is going to be removed from the React Native core. For more information, please read The Slimmening proposal.

reference: https://facebook.github.io/react-native/docs/webview.html